### PR TITLE
Make selfies use the real third person camera

### DIFF
--- a/src/Selfie.pas
+++ b/src/Selfie.pas
@@ -4,15 +4,18 @@ interface
 
 uses
   Math,
-  D3DX9, 
+  D3DX9,
   Direct3D9,
   Typestuff,
   muksoka;
 
+
 type TSelfie = class
 public
   isSelfieModeOn: boolean;
-  zoomlevel: (CLOSE, NORMAL, WIDE);
+  zoomlevel: single;
+  zoomlevelMax: single;
+  zoomlevelMin: single;
   dab: boolean;
   muks: TMuksoka;
   fejcuccrenderer: TFejcuccrenderer;
@@ -47,7 +50,9 @@ constructor TSelfie.Create(
 begin
   isSelfieModeOn := FALSE;
   dab := FALSE;
-  zoomlevel := CLOSE;
+  zoomlevelMax := 5;
+  zoomlevelMin:= 1.7;
+  zoomlevel := zoomlevelMin;
   muks := _muks;
   fegyv := _fegyv;
   fejcucc := _fejcucc;
@@ -65,7 +70,7 @@ begin
 
   if fegyv < 128 then szin := gunszin else szin := techszin;
   D3DXMatrixRotationY(matWorld2, camrotX); //+PI -PI lel
-  if zoomlevel = CLOSE then begin
+  if zoomlevel = zoomlevelMin then begin
     D3DXMatrixRotationX(matb, -camrotY*0.75);
   end else
     D3DXMatrixRotationX(matb, -camrotY*0.5);
@@ -100,19 +105,19 @@ begin
   end
   else
   begin
-    if zoomlevel = CLOSE then //fogom a kamerat
-    begin
+    //if zoomlevel = zoomlevelMin then //fogom a kamerat
+    //begin
       //arcomba rakom a kezem
-      muks.gmbk[8] := campos;
-      muks.gmbk[8].y := muks.gmbk[8].y + 0.2;
+     // muks.gmbk[8] := campos;
+      //muks.gmbk[8].y := muks.gmbk[8].y + 0.2;
 
       //jobb konyok kicsit kamera fele
-      muks.gmbk[6].x := muks.gmbk[6].x - 0.2;
-      muks.gmbk[6].y := muks.gmbk[6].y + 0.1;
-      muks.gmbk[6].z := muks.gmbk[6].z - 0.2;
-    end
-    else
-    begin
+      //muks.gmbk[6].x := muks.gmbk[6].x - 0.2;
+      //muks.gmbk[6].y := muks.gmbk[6].y + 0.1;
+      //muks.gmbk[6].z := muks.gmbk[6].z - 0.2;
+    //end
+    //else
+    //begin
       //jobb kezfej testem melle es le
       muks.gmbk[8].x := muks.gmbk[8].x - 0.1;
       muks.gmbk[8].y := muks.gmbk[8].y - 0.1;
@@ -121,7 +126,7 @@ begin
       //jobb konyok testem melle
       muks.gmbk[6].x := muks.gmbk[6].x - 0.1;
       muks.gmbk[6].z := muks.gmbk[6].z + 0.2;
-    end;
+    //end;
 
     //bal konyok testem melle es fel
     muks.gmbk[7].x := muks.gmbk[7].x + 0.2;

--- a/src/Selfie.pas
+++ b/src/Selfie.pas
@@ -60,34 +60,19 @@ procedure TSelfie.render;
 var
   szin: Cardinal;
   matWorld, matWorld2, matb: TD3DMatrix;
-  pos: TD3DXVector3;
-  cameraDistance: 1..5;
 begin
   if not isSelfieModeOn then exit;
 
-  cameraDistance := 2;
-  case zoomlevel of
-    CLOSE: cameraDistance := 1;
-    NORMAL: cameraDistance := 2;
-    WIDE: cameraDistance := 5;
-  end;
-
   if fegyv < 128 then szin := gunszin else szin := techszin;
-  D3DXVec3Add(
-    pos,
-    campos,
-    D3DXVector3(
-      sin(camrotX) * cameraDistance,
-      0,
-      cos(camrotX) * cameraDistance
-    )
-  );
   D3DXMatrixRotationY(matWorld2, camrotX); //+PI -PI lel
-  D3DXMatrixRotationX(matb, clipszogybajusz(camrotY));
+  if zoomlevel = CLOSE then begin
+    D3DXMatrixRotationX(matb, -camrotY*0.75);
+  end else
+    D3DXMatrixRotationX(matb, -camrotY*0.5);
   D3DXMatrixMultiply(matb, matb, matWorld2);
-  D3DXMatrixTranslation(matWorld, pos.x, pos.y, pos.z);
+  D3DXMatrixTranslation(matWorld, campos.x, campos.y, campos.z);
   D3DXMatrixMultiply(matWorld2, matWorld2, matWorld);
-  D3DXMatrixTranslation(matWorld, pos.x, pos.y, pos.z);
+  D3DXMatrixTranslation(matWorld, campos.x, campos.y, campos.z);
   D3DXMatrixMultiply(matb, matb, matWorld);
 
   if dab then
@@ -156,7 +141,7 @@ begin
   matb._41 := matb._41 + muks.gmbk[10].x;
   matb._42 := matb._42 + muks.gmbk[10].y;
   matb._43 := matb._43 + muks.gmbk[10].z;
-  fejcuccrenderer.render(fejcucc, matb, false, pos);
+  fejcuccrenderer.render(fejcucc, matb, false, campos);
 end;
 
 

--- a/src/Stickman.dpr
+++ b/src/Stickman.dpr
@@ -4516,7 +4516,7 @@ begin
       dine.keyd(DIK_A) or dine.keyd(DIK_D) then
       multisc.killscamping:=multisc.kills;
 
-  if dine.keyd(DIK_F) and (not autoban){$IFNDEF speedhack} and (autobaszallhat){$ENDIF} and (halal = 0) and (length(chatmost) = 0) then
+  if dine.keyd(DIK_F) and (not autoban){$IFNDEF speedhack} and (autobaszallhat){$ENDIF} and (halal = 0) and (length(chatmost) = 0) and (not selfieMaker.isSelfieModeOn) then
   begin
     freeandnil(tegla);autoban:=true;
     cpox^:=cpx^;cpoz^:=cpz^;cpoy^:=cpy^;
@@ -7611,7 +7611,8 @@ begin
     end
     else
     begin
-      kulsonezet:=false;
+      if not selfieMaker.isSelfieModeOn then
+        kulsonezet:=false;
       if vanishcar > 0 then
         inc(vanishcar);
     end;
@@ -8985,11 +8986,20 @@ begin
   // origin, and define "up" to be in the y-direction.    //campos camvec camcamcam
   vEyePt:=D3DXVector3(acpx + halal, acpy + 1.5 + halal / 3, acpz + halal);
   if kulsonezet then
+    if selfieMaker.isSelfieModeOn then
+    begin
+      case selfieMaker.zoomlevel of
+        CLOSE: vEyePt:=D3DXVector3(acpx - sin(szogx)* cos(szogy) * 1.75, acpy + 1.5 - sin(szogy) * 1.5, acpz - cos(szogx) * cos(szogy) * 1.75);
+        NORMAL: vEyePt:=D3DXVector3(acpx - sin(szogx) * 2, acpy + 1.5 - sin(szogy) * 2, acpz - cos(szogx) * 2);
+        WIDE: vEyePt:=D3DXVector3(acpx - sin(szogx) * 5, acpy + 1.5 - sin(szogy) * 5, acpz - cos(szogx) * 5);
+      end;
+    end else
     vEyePt:=D3DXVector3(acpx - sin(szogx) * cos(szogy) * 15, acpy + 1.5 - sin(szogy) * 15, acpz - cos(szogx) * cos(szogy) * 15);
 
   vLookatPt:=D3DXVector3(acpx + sin(szogx) * cos(szogy), acpy + 1.5 + sin(szogy), cos(szogx) * cos(szogy) + acpz);
   if halal > 0 then
   begin
+    selfieMaker.isSelfieModeOn := false;
     rbid:=getrongybababyID(0);
     if rbid >= 0 then
     begin
@@ -14428,7 +14438,7 @@ var
 
       selfieMaker.toggle;
       szogx := szogx + D3DX_PI;
-      nofegyv := selfieMaker.isSelfieModeOn;
+      kulsonezet := selfieMaker.isSelfieModeOn;
       selfieMaker.zoomlevel := NORMAL;
       selfieMaker.dab := FALSE;
     end;

--- a/src/Stickman.dpr
+++ b/src/Stickman.dpr
@@ -4394,16 +4394,11 @@ begin
   //SELFIE
   if selfieMaker.isSelfieModeOn then
   begin
-    if dine.keyprsd(DIK_X) then
-    begin
-      //evalscriptline('fastinfo X');
-      case selfieMaker.zoomlevel of
-        CLOSE: selfieMaker.zoomlevel := NORMAL;
-        NORMAL: selfieMaker.zoomlevel := WIDE;
-        WIDE: selfieMaker.zoomlevel := CLOSE;
-      end;
-      // y u no work ??? inc(selfieMaker.zoomlevel);
-    end;
+    if dine.MousMovScrl < 0 then
+      selfieMaker.zoomlevel := min(selfieMaker.zoomlevelMax, selfieMaker.zoomlevel + 0.1)
+    else if dine.MousMovScrl > 0 then
+      selfieMaker.zoomlevel := max(selfieMaker.zoomlevelMin, selfieMaker.zoomlevel - 0.1);
+
     if dine.keyprsd(DIK_B) then selfieMaker.dab := not selfieMaker.dab;
   end;
 
@@ -8988,13 +8983,13 @@ begin
   if kulsonezet then
     if selfieMaker.isSelfieModeOn then
     begin
-      case selfieMaker.zoomlevel of
-        CLOSE: vEyePt:=D3DXVector3(acpx - sin(szogx)* cos(szogy) * 1.75, acpy + 1.5 - sin(szogy) * 1.5, acpz - cos(szogx) * cos(szogy) * 1.75);
-        NORMAL: vEyePt:=D3DXVector3(acpx - sin(szogx) * 2, acpy + 1.5 - sin(szogy) * 2, acpz - cos(szogx) * 2);
-        WIDE: vEyePt:=D3DXVector3(acpx - sin(szogx) * 5, acpy + 1.5 - sin(szogy) * 5, acpz - cos(szogx) * 5);
-      end;
-    end else
-    vEyePt:=D3DXVector3(acpx - sin(szogx) * cos(szogy) * 15, acpy + 1.5 - sin(szogy) * 15, acpz - cos(szogx) * cos(szogy) * 15);
+      if selfieMaker.zoomlevel = selfieMaker.zoomlevelMin then
+        vEyePt:=D3DXVector3(acpx - sin(szogx) * cos(szogy) * selfieMaker.zoomlevel, acpy + 1.5 - sin(szogy) * 1.5, acpz - cos(szogx) * cos(szogy) * selfieMaker.zoomlevel)
+      else
+        vEyePt:=D3DXVector3(acpx - sin(szogx) * selfieMaker.zoomlevel, acpy + 1.5 - sin(szogy) * selfieMaker.zoomlevel, acpz - cos(szogx) * selfieMaker.zoomlevel);
+    end
+    else
+      vEyePt:=D3DXVector3(acpx - sin(szogx) * cos(szogy) * 15, acpy + 1.5 - sin(szogy) * 15, acpz - cos(szogx) * cos(szogy) * 15);
 
   vLookatPt:=D3DXVector3(acpx + sin(szogx) * cos(szogy), acpy + 1.5 + sin(szogy), cos(szogx) * cos(szogy) + acpz);
   if halal > 0 then
@@ -13383,6 +13378,7 @@ begin
   halal:=0;
   spectate:=0;
   mapmode:=0;
+  selfieMaker.isSelfieModeOn:=false;
   mapbol:=false;
 
   if volttim = 0 then volttim:=timegettime;
@@ -14439,7 +14435,7 @@ var
       selfieMaker.toggle;
       szogx := szogx + D3DX_PI;
       kulsonezet := selfieMaker.isSelfieModeOn;
-      selfieMaker.zoomlevel := NORMAL;
+      selfieMaker.zoomlevel := 2;
       selfieMaker.dab := FALSE;
     end;
 


### PR DESCRIPTION
Uses the built-in 3rd person camera instead of rotating the stickman around the 1st person cam.
Also disables getting into cars while in selfie mode.